### PR TITLE
Optional override of cache age when using fetch_rss().

### DIFF
--- a/rss_fetch.inc
+++ b/rss_fetch.inc
@@ -85,7 +85,7 @@ define('MAGPIE_VERSION', '0.80a');
 
 $MAGPIE_ERROR = "";
 
-function fetch_rss ($url) {
+function fetch_rss ($url, $cache_age=null) {
     // initialize constants
     init();
     
@@ -114,7 +114,8 @@ function fetch_rss ($url) {
         // 3. if cached obj fails freshness check, fetch remote
         // 4. if remote fails, return stale object, or error
         
-        $cache = new RSSCache( MAGPIE_CACHE_DIR, MAGPIE_CACHE_AGE );
+        $cache_age = $cache_age !== null ? $cache_age : MAGPIE_CACHE_AGE;
+        $cache = new RSSCache( MAGPIE_CACHE_DIR, $cache_age );
         
         if (MAGPIE_DEBUG and $cache->ERROR) {
             debug($cache->ERROR, E_USER_WARNING);

--- a/rss_parse.inc
+++ b/rss_parse.inc
@@ -159,14 +159,14 @@ class MagpieRSS {
         $el = $element = strtolower($element);
         $attrs = array_change_key_case($attrs, CASE_LOWER);
         
-        # check for a namespace, and split if found
+        # check for a namespace, and explode if found
         # only if we're not inside a content tag
         
         if ( empty($this->incontent) ) {   
             $ns = false;
             
             if ( strpos( $element, ':' ) ) {
-                list($ns, $el) = split( ':', $element, 2); 
+                list($ns, $el) = explode( ':', $element, 2); 
             }
             
             if ( $ns and $ns != 'rdf' ) {
@@ -360,7 +360,7 @@ class MagpieRSS {
 
             # Don't get bamboozled by namespace voodoo
             if (strpos($el, ':')) { 
-                list($ns, $closer) = split(':', $el); 
+                list($ns, $closer) = explode(':', $el); 
             }
             else { 
                 $ns = false; $closer = $el; 


### PR DESCRIPTION
Added optional $cache_age parameter to fetch_rss() to facilitate override of defined MAGPIE_CACHE_AGE.
