### PR TITLE
Use PHP 5-style constructors instead of legacy constructors

### DIFF
--- a/rss_cache.inc
+++ b/rss_cache.inc
@@ -21,7 +21,7 @@ class RSSCache {
     var $MAX_AGE    = 3600;         // when are files stale, default one hour
     var $ERROR      = "";           // accumulate error messages
     
-    function RSSCache ($base='', $age='') {
+    function __construct ($base='', $age='') {
         if ( $base ) {
             $this->BASE_CACHE = $base;
         }

--- a/rss_parse.inc
+++ b/rss_parse.inc
@@ -104,7 +104,7 @@ class MagpieRSS {
      *                                  source encoding. (caveat emptor)
      *
      */
-    function MagpieRSS ($source, $output_encoding='ISO-8859-1', 
+    function __construct ($source, $output_encoding='ISO-8859-1', 
                         $input_encoding=null, $detect_encoding=true) 
     {   
         #


### PR DESCRIPTION
Resolves a deprecation warning in PHP 7. Breaks compatibility with PHP 4.x, but nobody should be using that any more...
